### PR TITLE
[Discovery] : adding CSS for blue link

### DIFF
--- a/static/css/fintual.css
+++ b/static/css/fintual.css
@@ -162,6 +162,25 @@ a:hover {
   text-decoration: none;
 }
 
+a.discovery {
+  background:
+      linear-gradient(
+        to bottom, #A0C8FF 0%,
+        #A0C8FF 100%
+      );
+    background-position: 0 100%;
+    background-repeat: repeat-x;
+    background-size: 4px 6px;
+  color: #000;
+  text-decoration: none;
+  transition: background-size .2s;
+}
+
+a.discovery:hover {
+  background-size: 4px 50px;
+}
+
+
 .mainheading,
 .posttitle {
   font-family: Poppins;


### PR DESCRIPTION
When you create a link in a post with `class="discovery"` it will show like this: 
normal:
![Screen Shot 2020-07-01 at 12 16 20](https://user-images.githubusercontent.com/1921575/86267886-5f343680-bb95-11ea-9f73-8bb7ef167c11.png)

hover:
![Screen Shot 2020-07-01 at 12 16 24](https://user-images.githubusercontent.com/1921575/86267876-5d6a7300-bb95-11ea-83da-dbbf397dc25f.png)
